### PR TITLE
Code changes to support Python 3.7 and above

### DIFF
--- a/flickr-dump
+++ b/flickr-dump
@@ -1,24 +1,27 @@
 #!/usr/bin/env python3
+import asyncio
 from argparse import ArgumentParser
 from flickrdump import flickrdump
 
-def main():
-    """
-    Flickr-Dump CLI funciton.
-    """
+def parse_args():
     parser = ArgumentParser(description='Flickr Dump')
     parser.add_argument('-A', '--api-key', required=True,
-        help='An API-key for accessing the Flickr API.')
+                        help='An API-key for accessing the Flickr API.')
     parser.add_argument('-S', '--api-secret', required=True,
-        help='An API-secret for accessing the Flickr API.')
+                        help='An API-secret for accessing the Flickr API.')
     parser.add_argument('-U', '--user-id', required=True,
-        help='Your Flickr UserID, Can be found at http://idgettr.com/')
+                        help='Your Flickr UserID, Can be found at http://idgettr.com/')
     parser.add_argument('-P', '--path', default='./data',
-        help='The target path to download photos')
+                        help='The target path to download photos')
+    return parser.parse_args()
 
-    args = parser.parse_args()
-    return flickrdump.dump(args.api_key, args.api_secret, args.user_id,
-                           args.path)
+def main():
+    """
+    Flickr-Dump CLI function.
+    """
+    args = parse_args()
+    # Run the async dump function using asyncio.run
+    return asyncio.run(flickrdump.dump(args.api_key, args.api_secret, args.user_id, args.path))
 
 if __name__ == '__main__':
     exit(main())

--- a/flickrdump/flickrdump.py
+++ b/flickrdump/flickrdump.py
@@ -16,8 +16,6 @@ async def dump(api, secret, user_id, target='./data'):
         return 1
     except KeyboardInterrupt:
         print('Stopped')
-    finally:
-        loop.close()
 
     return 0
 

--- a/flickrdump/flickrdump.py
+++ b/flickrdump/flickrdump.py
@@ -1,22 +1,17 @@
-from __future__ import division
 import sys
-if sys.version_info < (3, 4):
-    raise Exception('')
-    exit(1)
-
 import asyncio
 import aiohttp
 import functools
 import flickrapi
-import itertools
 import os
 
-from ctypes import c_bool
+COUNT_LOCK = asyncio.Lock()
+COUNT_DLS = [0, 0]
 
-def dump(api, secret, user_id, target='./data'):
+async def dump(api, secret, user_id, target='./data'):
     try:
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(_dump(api, secret, user_id, target))
+        await _dump(api, secret, user_id, target)
     except OSError:
         return 1
     except KeyboardInterrupt:
@@ -26,7 +21,7 @@ def dump(api, secret, user_id, target='./data'):
 
     return 0
 
-def _dump(api, secret, user_id, target):
+async def _dump(api, secret, user_id, target):
     if not os.path.exists(target):
         os.makedirs(target)
 
@@ -35,70 +30,56 @@ def _dump(api, secret, user_id, target):
         user_id=user_id, per_page=500, page=1)['photos']['pages']
     print('Total pages to download:', pages)
 
-    coros = []
-    for i in range(pages):
-        coros.append(asyncio.Task(_get_urls(flickr, user_id, i + 1, target)))
-
-    yield from asyncio.gather(*coros)
+    coros = [asyncio.create_task(_get_urls(flickr, user_id, i + 1, target)) for i in range(pages)]
+    await asyncio.gather(*coros)
     sys.stdout.write('\n')
     print('done!')
 
-COUNT_LOCK = asyncio.Lock()
-COUNT_DLS = [0, 0]
-@asyncio.coroutine
-def _count(i, incr=False):
+async def _count(i, incr=False):
     global COUNT_DLS
-    with (yield from COUNT_LOCK):
+    async with COUNT_LOCK:
         if incr:
             COUNT_DLS[i] += 1
         return COUNT_DLS[i]
 
-@asyncio.coroutine
-def _download(url, target):
+async def _download(url, target):
     filename = url.split('/')[-1]
 
-    dl = yield from _count(1, True)
-    cnt = yield from _count(0)
+    dl = await _count(1, True)
+    cnt = await _count(0)
     sys.stdout.write('[{}/{}, {:.02f}%] Downloading..\r'.format(
         cnt, dl, (cnt / dl * 100.0)))
     sys.stdout.flush()
 
-    target = '{}/{}'.format(target, filename)
-    r = yield from aiohttp.request('get', url)
-    with open(target, 'wb') as fd:
-        while True:
-            chunk = yield from r.content.read(1024)
-            if not chunk:
-                break
-            fd.write(chunk)
-    r.close()
+    target_path = f'{target}/{filename}'
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            with open(target_path, 'wb') as fd:
+                while chunk := await response.content.read(1024):
+                    fd.write(chunk)
 
-    cnt = yield from _count(0, True)
+    await _count(0, True)
 
-@asyncio.coroutine
-def _get_urls(flickr, user_id, p, target):
+async def _get_urls(flickr, user_id, p, target):
     items = flickr.people.getPublicPhotos(
         user_id=user_id, per_page=500, page=p)['photos']['photo']
     count = len(items)
 
-    for i, item in enumerate(items):
+    for item in items:
         item_id, item_secret = item.get('id'), item.get('secret')
-        res = yield from asyncio.async(_get_url(flickr, item_id, item_secret))
-        asyncio.async(_download(res, target))
+        res = await _get_url(flickr, item_id, item_secret)
+        asyncio.create_task(_download(res, target))
 
     return count
 
-@asyncio.coroutine
-def _get_url(flickr, item_id, item_secret):
+async def _get_url(flickr, item_id, item_secret):
     loop = asyncio.get_event_loop()
     sizes_callback = functools.partial(flickr.photos.getSizes, photo_id=item_id)
-    sizes = loop.run_in_executor(None, sizes_callback)
-    sizes = yield from sizes
+    sizes = await loop.run_in_executor(None, sizes_callback)
 
     sizes = sizes.get('sizes').get('size')
-    original = ''
     try:
         original = next(d for d in sizes if d['label'] == 'Original')
-    except: pass
-
-    return original.get('source', '')
+        return original.get('source', '')
+    except StopIteration:
+        return ''


### PR DESCRIPTION
Python 3.7 and above has major changes with asyncio. Updated the code to support them. The existing code did not work with Python >3.7.

There is **NO** change to logic, the logic remains the same.

Updates to `flickrdump/flickrdump.py` -
- Replaced `@asyncio.coroutine`: All coroutine functions now use `async def`.
- Replaced `yield from`: The modern syntax uses `await`.
- Replaced `asyncio.async`: Use `asyncio.create_task()` to schedule tasks.
- Improved `aiohttp` usage: Added proper context management for HTTP requests using `aiohttp.ClientSession`.

Updates to `flickr-dump` -
- Used `asyncio.run()` to run the async `dump()` function properly.
- Moved argument parsing to a separate `parse_args()` function for clarity.
- Kept the rest of the CLI logic unchanged, as argparse usage remains the same in Python >3.7.

Fixes: #1 